### PR TITLE
Add Stream with Filter example to sample directory

### DIFF
--- a/sample/stream.hs
+++ b/sample/stream.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+
+import Web.Twitter.Conduit
+import Web.Twitter.Types.Lens
+import Common
+
+import Control.Applicative
+import Control.Lens
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Conduit
+import qualified Data.Conduit as C
+import qualified Data.Conduit.Binary as CB
+import qualified Data.Conduit.List as CL
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Network.HTTP.Conduit as HTTP
+import System.Directory
+import System.FilePath
+import System.Process
+
+ensureDirectoryExist :: FilePath -> IO FilePath
+ensureDirectoryExist dir = do
+    createDirectoryIfMissing True dir
+    return dir
+
+confdir :: IO FilePath
+confdir = fmap (</> ".twitter-conduit") getHomeDirectory >>= ensureDirectoryExist
+
+iconPath :: IO FilePath
+iconPath = (</> "icons") <$> confdir >>= ensureDirectoryExist
+
+main :: IO ()
+main = do
+    twInfo <- getTWInfoFromEnv
+    withManager $ \mgr -> do
+        src <- stream twInfo mgr userstream
+        src C.$$+- CL.mapM_ (liftIO . printTL)
+
+showStatus :: AsStatus s => s -> T.Text
+showStatus s = T.concat [ s ^. user . userScreenName
+                        , ":"
+                        , s ^. text
+                        ]
+
+printTL :: StreamingAPI -> IO ()
+printTL (SStatus s) = T.putStrLn . showStatus $ s
+printTL (SRetweetedStatus s) = T.putStrLn $ T.concat [ s ^. user . userScreenName
+                                                     , ": RT @"
+                                                     , showStatus (s ^. rsRetweetedStatus)
+                                                     ]
+printTL (SEvent event)
+    | (event^.evEvent) == "favorite" || (event^.evEvent) == "unfavorite",
+      Just (ETStatus st) <- event ^. evTargetObject = do
+          let (fromUser, fromIcon) = evUserInfo (event^.evSource)
+              (toUser, _toIcon) = evUserInfo (event^.evTarget)
+              evUserInfo (ETUser u) = (u ^. userScreenName, u ^. userProfileImageURL)
+              evUserInfo _ = ("", Nothing)
+              header = T.concat [ event ^. evEvent, "[", fromUser, " -> ", toUser, "]"]
+          T.putStrLn $ T.concat [ header, " :: ", showStatus st ]
+          icon <- case fromIcon of
+              Just iconUrl -> Just <$> fetchIcon (T.unpack fromUser) (T.unpack iconUrl)
+              Nothing -> return Nothing
+          notifySend header (showStatus st) icon
+printTL s = print s
+
+notifySend :: T.Text -> T.Text -> Maybe FilePath -> IO ()
+notifySend header content icon = do
+    let ic = maybe [] (\i -> ["-i", i]) icon
+    void $ rawSystem "notify-send" $ [T.unpack header, T.unpack content] ++ ic
+
+fetchIcon :: String -- ^ screen name
+          -> String -- ^ icon url
+          -> IO String
+fetchIcon sn url = do
+    ipath <- iconPath
+    let fname = ipath </> sn ++ "__" ++ takeFileName url
+    exists <- doesFileExist fname
+    unless exists $ withManager $ \mgr -> do
+        req <- liftIO $ parseUrl url
+        body <- http req mgr
+        HTTP.responseBody body $$+- CB.sinkFile fname
+    return fname

--- a/sample/stream.hs
+++ b/sample/stream.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+module Main where
+
 import Web.Twitter.Conduit
 import Web.Twitter.Types.Lens
 import Common
@@ -15,14 +17,16 @@ import qualified Data.Conduit.List as CL
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Network.HTTP.Conduit as HTTP
+import System.Environment
 
 main :: IO ()
 main = do
-    [keyword] < - getArgs
+    [keyword] <- getArgs
 
     twInfo <- getTWInfoFromEnv
+
     withManager $ \mgr -> do
-        src <- stream twInfo mgr $ search $ T.pack keyword
+        src <- stream twInfo mgr $ statusesFilterByTrack $ T.pack keyword
         src C.$$+- CL.mapM_ (liftIO . printTL)
 
 printTL :: StreamingAPI -> IO ()

--- a/sample/stream.hs
+++ b/sample/stream.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
 
 import Web.Twitter.Conduit
 import Web.Twitter.Types.Lens
@@ -16,69 +15,16 @@ import qualified Data.Conduit.List as CL
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Network.HTTP.Conduit as HTTP
-import System.Directory
-import System.FilePath
-import System.Process
-
-ensureDirectoryExist :: FilePath -> IO FilePath
-ensureDirectoryExist dir = do
-    createDirectoryIfMissing True dir
-    return dir
-
-confdir :: IO FilePath
-confdir = fmap (</> ".twitter-conduit") getHomeDirectory >>= ensureDirectoryExist
-
-iconPath :: IO FilePath
-iconPath = (</> "icons") <$> confdir >>= ensureDirectoryExist
 
 main :: IO ()
 main = do
+    [keyword] < - getArgs
+
     twInfo <- getTWInfoFromEnv
     withManager $ \mgr -> do
-        src <- stream twInfo mgr userstream
+        src <- stream twInfo mgr $ search $ T.pack keyword
         src C.$$+- CL.mapM_ (liftIO . printTL)
 
-showStatus :: AsStatus s => s -> T.Text
-showStatus s = T.concat [ s ^. user . userScreenName
-                        , ":"
-                        , s ^. text
-                        ]
-
 printTL :: StreamingAPI -> IO ()
-printTL (SStatus s) = T.putStrLn . showStatus $ s
-printTL (SRetweetedStatus s) = T.putStrLn $ T.concat [ s ^. user . userScreenName
-                                                     , ": RT @"
-                                                     , showStatus (s ^. rsRetweetedStatus)
-                                                     ]
-printTL (SEvent event)
-    | (event^.evEvent) == "favorite" || (event^.evEvent) == "unfavorite",
-      Just (ETStatus st) <- event ^. evTargetObject = do
-          let (fromUser, fromIcon) = evUserInfo (event^.evSource)
-              (toUser, _toIcon) = evUserInfo (event^.evTarget)
-              evUserInfo (ETUser u) = (u ^. userScreenName, u ^. userProfileImageURL)
-              evUserInfo _ = ("", Nothing)
-              header = T.concat [ event ^. evEvent, "[", fromUser, " -> ", toUser, "]"]
-          T.putStrLn $ T.concat [ header, " :: ", showStatus st ]
-          icon <- case fromIcon of
-              Just iconUrl -> Just <$> fetchIcon (T.unpack fromUser) (T.unpack iconUrl)
-              Nothing -> return Nothing
-          notifySend header (showStatus st) icon
-printTL s = print s
+printTL = print
 
-notifySend :: T.Text -> T.Text -> Maybe FilePath -> IO ()
-notifySend header content icon = do
-    let ic = maybe [] (\i -> ["-i", i]) icon
-    void $ rawSystem "notify-send" $ [T.unpack header, T.unpack content] ++ ic
-
-fetchIcon :: String -- ^ screen name
-          -> String -- ^ icon url
-          -> IO String
-fetchIcon sn url = do
-    ipath <- iconPath
-    let fname = ipath </> sn ++ "__" ++ takeFileName url
-    exists <- doesFileExist fname
-    unless exists $ withManager $ \mgr -> do
-        req <- liftIO $ parseUrl url
-        body <- http req mgr
-        HTTP.responseBody body $$+- CB.sinkFile fname
-    return fname

--- a/twitter-conduit.cabal
+++ b/twitter-conduit.cabal
@@ -223,6 +223,39 @@ executable userstream
   else
     build-depends: network < 2.6
 
+executable stream
+  main-is: stream.hs
+  hs-source-dirs: sample/
+
+  if !flag(build-samples)
+    buildable: False
+  else
+    build-depends:
+        base >= 4.5 && < 5
+      , containers
+      , transformers-base
+      , transformers
+      , monad-control
+      , bytestring
+      , text
+      , case-insensitive
+      , lens
+      , aeson
+      , data-default
+      , resourcet
+      , conduit
+      , conduit-extra
+      , http-conduit
+      , authenticate-oauth
+      , twitter-conduit
+      , twitter-types
+      , twitter-types-lens
+
+  if flag(network-uri)
+    build-depends: network-uri >= 2.6
+  else
+    build-depends: network < 2.6
+
 executable oauth_callback
   main-is: oauth_callback.hs
   hs-source-dirs: sample/


### PR DESCRIPTION
Add stream with filter example to sample directory. Also update twitter-conduit.cabal to build stream.hs example.

Testing how PR looks on local fork.
